### PR TITLE
Adding pattern and inputMode to CEPInput

### DIFF
--- a/src/components/CEPInput.tsx
+++ b/src/components/CEPInput.tsx
@@ -6,7 +6,14 @@ import { masks } from '../constants'
 type Props = Omit<React.ComponentPropsWithoutRef<typeof MaskedInput>, 'mask'>
 
 const CepInput: FC<Props> = ({ ...props }) => {
-  return <MaskedInput {...props} mask={masks.CEP} />
+  return (
+    <MaskedInput
+      {...props}
+      inputMode="numeric"
+      pattern="[0-9]*"
+      mask={masks.CEP}
+    />
+  )
 }
 
 export default CepInput


### PR DESCRIPTION
https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/